### PR TITLE
Connectedブロック表示改善 (issue #1)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -562,8 +562,8 @@ function drawGame() {
     // Connected cellsの詳細情報を取得して数字を描画
     const connectedCellsInfo = gameState.get_connected_cells_info();
     if (connectedCellsInfo && connectedCellsInfo.length > 0) {
-        ctx.fillStyle = '#ffffff';
-        ctx.font = `${Math.min(cellWidth, cellHeight) * 0.5}px Arial`;
+        // フォントサイズを大幅に拡大 - ブロックいっぱいまで大きく
+        ctx.font = `bold ${Math.min(cellWidth, cellHeight) * 0.8}px Arial`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         
@@ -574,9 +574,18 @@ function drawGame() {
             
             const pixelX = x * cellWidth;
             const pixelY = y * cellHeight;
+            const centerX = pixelX + cellWidth / 2;
+            const centerY = pixelY + cellHeight / 2;
+            const text = count.toString();
             
-            // 連結数を表示
-            ctx.fillText(count.toString(), pixelX + cellWidth / 2, pixelY + cellHeight / 2);
+            // 方法2: 黒いふちどりを先に描画（プロフェッショナルな見た目）
+            ctx.strokeStyle = '#000000';
+            ctx.lineWidth = Math.max(3, Math.min(cellWidth, cellHeight) * 0.12); // ふちどりを太く調整
+            ctx.strokeText(text, centerX, centerY);
+            
+            // 白い文字を上に描画（華やかさと特別感を演出）
+            ctx.fillStyle = '#ffffff';
+            ctx.fillText(text, centerX, centerY);
         }
     }
     
@@ -657,15 +666,15 @@ function getCellColor(cellValue: number): string {
         case 8: return '#000000'; // Black
         case 9: return '#808080'; // Dark Grey
         
-        // Connected cells (10+) - CLI版の3色スコアリング用
-        case 10: return '#00cccc'; // Connected Cyan (0+10)
-        case 11: return '#cc00cc'; // Connected Magenta (1+10)
-        case 12: return '#cccc00'; // Connected Yellow (2+10)
+        // Connected cells (10+) - より明るく目立つ色に変更
+        case 10: return '#00ffff'; // Connected Cyan - 通常ピースと同じ明るさ
+        case 11: return '#ff00ff'; // Connected Magenta - 通常ピースと同じ明るさ  
+        case 12: return '#ffff00'; // Connected Yellow - 通常ピースと同じ明るさ
         
-        // その他のConnected cells（後方互換性）
-        case 13: return '#cc0000'; // Connected Red
-        case 14: return '#00cc00'; // Connected Green
-        case 15: return '#0000cc'; // Connected Blue
+        // その他のConnected cells（明るく調整）
+        case 13: return '#ff4444'; // Connected Red - より明るく
+        case 14: return '#44ff44'; // Connected Green - より明るく
+        case 15: return '#4444ff'; // Connected Blue - より明るく
         
         // Special cells
         case 20: return '#666666'; // Gray

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   base: '/thud-and-tile-web/', // GitHub Pages用のベースパス
   server: {
+    host: '0.0.0.0', // 外部アクセスを許可
+    port: 5173,      // ポート番号を明示
     fs: {
       allow: ['..']
     }


### PR DESCRIPTION
- フォントサイズを0.5倍から0.8倍に拡大してブロックいっぱいまで大きく
- ブロック色を明るく変更して通常ピースより目立つように調整
- 白文字に黒いふちどりを追加して視認性とデザイン性を両立
- 開発サーバーを外部アクセス可能に設定してモバイルテスト対応

Fixes #1